### PR TITLE
Update package.json to fix coc install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
         "typescript": "^3.0.3",
         "coc.nvim": "^0.0.77"
     },
+    "engines": {
+        "coc": ">=0.0.77"
+    },
     "files": [
         "out"
     ],


### PR DESCRIPTION
Fixes 
"coc-utils is not valid coc extension, "engines" field with coc property required"
error when trying to update/install coc-utils